### PR TITLE
Setting `bot-email` during github actions run

### DIFF
--- a/.github/auto-release-config.yml
+++ b/.github/auto-release-config.yml
@@ -38,10 +38,13 @@ categories:
 change-template: |
   <details>
     <summary>$TITLE @$AUTHOR (#$NUMBER)</summary>
+
     $BODY
   </details>
+
 template: |
   $CHANGES
+
 replacers:
 # Remove irrelevant information from Renovate bot
 - search: '/(?<=---\s)\s*^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'

--- a/.github/workflows/auto-context-reusable.yml
+++ b/.github/workflows/auto-context-reusable.yml
@@ -30,4 +30,5 @@ jobs:
         branch-name: ${{ inputs.branch-name }}
         bot-name: ${{ inputs.bot-name }}
         bot-email: ${{ inputs.bot-email }}
+      secrets:
         token: ${{ secrets.token }}

--- a/.github/workflows/auto-context-reusable.yml
+++ b/.github/workflows/auto-context-reusable.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     inputs:
       branch-name:
-        description: "Name of branch to commit updated context.tf to"
+        description: "Name of branch where the updated context.tf will be added"
         type: string
         required: false
         default: "auto-update/context.tf"

--- a/.github/workflows/auto-context-reusable.yml
+++ b/.github/workflows/auto-context-reusable.yml
@@ -19,7 +19,6 @@ on:
     secrets:
       token:
         required: false
-        default: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   auto-context:
@@ -30,5 +29,4 @@ jobs:
         branch-name: ${{ inputs.branch-name }}
         bot-name: ${{ inputs.bot-name }}
         bot-email: ${{ inputs.bot-email }}
-      secrets:
         token: ${{ secrets.token }}

--- a/.github/workflows/auto-context-reusable.yml
+++ b/.github/workflows/auto-context-reusable.yml
@@ -8,7 +8,7 @@ on:
         required: false
         default: "auto-update/context.tf"
       bot-name:
-        description: "Username to write commits under"
+        description: "GitHub username the action will use to commit code"
         type: string
         required: false
         default: "cloudpossebot"

--- a/.github/workflows/auto-context-reusable.yml
+++ b/.github/workflows/auto-context-reusable.yml
@@ -1,0 +1,33 @@
+name: "auto-context-reusable"
+on:
+  workflow_call:
+    inputs:
+      branch-name:
+        description: "Name of branch to commit updated context.tf to"
+        type: string
+        required: false
+        default: "auto-update/context.tf"
+      bot-name:
+        decription: "Username to write commits under"
+        type: string
+        required: false
+        default: "cloudpossebot"
+      bot-email:
+        decription: "Email to write commits under"
+        type: string
+        required: false
+    secrets:
+      token:
+        required: false
+        default: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  auto-context:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: cloudposse/github-action-terraform-auto-context@improve-bot-email-default
+      with:
+        branch-name: ${{ inputs.branch-name }}
+        bot-name: ${{ inputs.bot-name }}
+        bot-email: ${{ inputs.bot-email }}
+        token: ${{ secrets.token }}

--- a/.github/workflows/auto-context-reusable.yml
+++ b/.github/workflows/auto-context-reusable.yml
@@ -8,12 +8,12 @@ on:
         required: false
         default: "auto-update/context.tf"
       bot-name:
-        decription: "Username to write commits under"
+        description: "Username to write commits under"
         type: string
         required: false
         default: "cloudpossebot"
       bot-email:
-        decription: "Email to write commits under"
+        description: "Email to write commits under"
         type: string
         required: false
     secrets:

--- a/.github/workflows/auto-context-reusable.yml
+++ b/.github/workflows/auto-context-reusable.yml
@@ -24,7 +24,7 @@ jobs:
   auto-context:
     runs-on: ubuntu-latest
     steps:
-    - uses: cloudposse/github-action-terraform-auto-context@improve-bot-email-default
+    - uses: cloudposse/github-action-terraform-auto-context@main
       with:
         branch-name: ${{ inputs.branch-name }}
         bot-name: ${{ inputs.bot-name }}

--- a/.github/workflows/auto-context-reusable.yml
+++ b/.github/workflows/auto-context-reusable.yml
@@ -13,7 +13,7 @@ on:
         required: false
         default: "cloudpossebot"
       bot-email:
-        description: "Email Address associated with the GitHub user the action will use to commit code"
+        description: "Email address associated with the GitHub user the action will use to commit code"
         type: string
         required: false
     secrets:

--- a/.github/workflows/auto-context-reusable.yml
+++ b/.github/workflows/auto-context-reusable.yml
@@ -13,7 +13,7 @@ on:
         required: false
         default: "cloudpossebot"
       bot-email:
-        description: "Email to write commits under"
+        description: "Email Address associated with the GitHub user the action will use to commit code"
         type: string
         required: false
     secrets:

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   auto-context:
-    uses: cloudposse/github-action-terraform-auto-context/.github/workflows/auto-context-reusable@improve-bot-email-default
+    uses: cloudposse/github-action-terraform-auto-context/.github/workflows/auto-context-reusable.yml@improve-bot-email-default
     with:
       # Name of branch to commit updated context.tf to
       branch-name: auto-update/context.tf

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -12,3 +12,4 @@ jobs:
     - uses: cloudposse/github-action-terraform-auto-context@improve-bot-email-default
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
+        bot-email: "placeholder"

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -9,7 +9,6 @@ jobs:
   auto-context:
     runs-on: ubuntu-latest
     steps:
-    - uses: cloudposse/github-action-terraform-auto-context@improve-bot-email-default
+    - uses: cloudposse/github-action-terraform-auto-context@main
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        bot-email: "placeholder"

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -7,11 +7,11 @@ on:
 
 jobs:
   auto-context:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: cloudposse/github-action-terraform-auto-context/.github/workflows/auto-context-reusable@improve-bot-email-default
-      with:
-        branch-name: ${{ inputs.branch-name }}
-        bot-name: ${{ inputs.bot-name }}
-        bot-email: ${{ inputs.bot-email }}
-        token: ${{ secrets.GITHUB_TOKEN }}
+    uses: cloudposse/github-action-terraform-auto-context/.github/workflows/auto-context-reusable@improve-bot-email-default
+    with:
+      # Name of branch to commit updated context.tf to
+      branch-name: auto-update/context.tf
+      # GitHub username to use for automated commits (should be a real GitHub user)
+      bot-name: cloudpossebot
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -9,6 +9,9 @@ jobs:
   auto-context:
     runs-on: ubuntu-latest
     steps:
-    - uses: cloudposse/github-action-terraform-auto-context@main
+    - uses: cloudposse/github-action-terraform-auto-context/.github/workflows/auto-context-reusable@improve-bot-email-default
       with:
+        branch-name: ${{ inputs.branch-name }}
+        bot-name: ${{ inputs.bot-name }}
+        bot-email: ${{ inputs.bot-email }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -9,6 +9,6 @@ jobs:
   auto-context:
     runs-on: ubuntu-latest
     steps:
-    - uses: cloudposse/github-action-terraform-auto-context@main
+    - uses: cloudposse/github-action-terraform-auto-context@improve-bot-email-default
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   auto-context:
-    uses: cloudposse/github-action-terraform-auto-context/.github/workflows/auto-context-reusable.yml@improve-bot-email-default
+    uses: cloudposse/github-action-terraform-auto-context/.github/workflows/auto-context-reusable.yml@main
     with:
       # Name of branch to commit updated context.tf to
       branch-name: auto-update/context.tf

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,3 +1,8 @@
+# Please see
+# https://github.com/cloudposse/github-action-auto-release/blob/main/README.md
+# and
+# https://github.com/release-drafter/release-drafter
+# for information on customizing this action's behavior.
 name: "auto-release"
 on:
   push:
@@ -5,13 +10,16 @@ on:
       - main
       - master
       - production
+  workflow_dispatch:
 
 jobs:
   auto-release:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: cloudposse/github-action-auto-release@main
-      with:
-        prerelease: false
-        publish: true
-        token: ${{ secrets.GITHUB_TOKEN }}
+    # For development reasons, this action is pinned to the `main` branch.
+    # However, we recommend that you choose a specific release to pin to.
+    # Consult https://github.com/cloudposse/github-action-auto-release/releases for a list of available releases.
+    uses: cloudposse/github-action-auto-release/.github/workflows/auto-release-reusable.yml@main
+    with:
+      prerelease: false
+      publish: true
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,6 @@ runs:
         else
           bot_email=${{ inputs.bot-email }}
         fi
-        echo $bot_email
         echo "::set-output name=bot-email::${bot_email}"
 
     - name: "Checkout commit"

--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,18 @@ inputs:
   bot-email:
     decription: "Email to write commits under"
     required: false
-    default: "11232728+cloudpossebot@users.noreply.github.com"
 runs:
   using: "composite"
   steps:
+    - name: "Set bot-email to cloudpossebot default, if none specified"
+      if: inputs.bot-email == ''
+      shell: bash
+      run: |
+        bot_id=$(curl -sSL 'https://api.github.com/users/cloudpossebot' | jq .id)
+        bot_email=${bot_id}+cloudpossebot@users.noreply.github.com
+        echo $bot_email
+        echo "::set-output name=bot-email::${bot_email}"
+
     - name: "Checkout commit"
       uses: actions/checkout@v2
 

--- a/action.yml
+++ b/action.yml
@@ -31,12 +31,6 @@ runs:
         echo $bot_email
         echo "::set-output name=bot-email::${bot_email}"
 
-    - name: "Debugging"
-      shell: bash
-      run: |
-        echo "inputs.bot-email: ${{ inputs.bot-email}}"
-        echo "steps.bot-email-set.outputs.bot-email: ${{ steps.bot-email-set.outputs.bot-email }}"
-
     - name: "Checkout commit"
       uses: actions/checkout@v2
 
@@ -47,7 +41,6 @@ runs:
         entrypoint: /github/workspace/context_update.sh
       env:
         BRANCH_NAME: ${{ inputs.branch-name }}
-        BOT_NAME: ${{ inputs.bot-name }}
         HOST_REPO: ${{ github.repository }}
 
     - name: Create Pull Request

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: "Set bot-email to cloudpossebot default, if none specified"
+      id: bot-email-set
       if: inputs.bot-email == ''
       shell: bash
       run: |
@@ -26,6 +27,12 @@ runs:
         bot_email=${bot_id}+cloudpossebot@users.noreply.github.com
         echo $bot_email
         echo "::set-output name=bot-email::${bot_email}"
+
+    - name: "Debugging"
+      shell: bash
+      run: |
+        echo "inputs.bot-email: ${{ inputs.bot-email}}"
+        echo "steps.bot-email-set.outputs.bot-email: ${{ steps.bot-email-set.outputs.bot-email }}"
 
     - name: "Checkout commit"
       uses: actions/checkout@v2

--- a/action.yml
+++ b/action.yml
@@ -18,13 +18,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: "Set bot-email to cloudpossebot default if inputs.bot-email not provided"
+    - name: "Set bot-email to GitHub default if inputs.bot-email not provided"
       id: bot-email-set
       shell: bash
       run: |
         if [ -z ${{ inputs.bot-email }} ]; then
-          bot_id=$(curl -sSL 'https://api.github.com/users/cloudpossebot' | jq .id)
-          bot_email=${bot_id}+cloudpossebot@users.noreply.github.com
+          bot_id=$(curl -sSL 'https://api.github.com/users/${{ inputs.bot-name }}' | jq .id)
+          bot_email=${bot_id}+${{ inputs.bot-name }}@users.noreply.github.com
         else
           bot_email=${{ inputs.bot-email }}
         fi

--- a/action.yml
+++ b/action.yml
@@ -18,13 +18,16 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: "Set bot-email to cloudpossebot default, if none specified"
+    - name: "Set bot-email to cloudpossebot default if inputs.bot-email not provided"
       id: bot-email-set
-      if: inputs.bot-email == ''
       shell: bash
       run: |
-        bot_id=$(curl -sSL 'https://api.github.com/users/cloudpossebot' | jq .id)
-        bot_email=${bot_id}+cloudpossebot@users.noreply.github.com
+        if [ -z ${{ inputs.bot-email }} ]; then
+          bot_id=$(curl -sSL 'https://api.github.com/users/cloudpossebot' | jq .id)
+          bot_email=${bot_id}+cloudpossebot@users.noreply.github.com
+        else
+          bot_email=${{ inputs.bot-email }}
+        fi
         echo $bot_email
         echo "::set-output name=bot-email::${bot_email}"
 

--- a/action.yml
+++ b/action.yml
@@ -54,8 +54,8 @@ runs:
       uses: peter-evans/create-pull-request@v4.0.2
       with:
         token: ${{ inputs.token }}
-        committer: '${{ inputs.bot-name }} <${{inputs.bot-email}}>'
-        author: '${{ inputs.bot-name }} <${{inputs.bot-email}}>'
+        committer: '${{ inputs.bot-name }} <${{steps.bot-email-set.outputs.bot-email}}>'
+        author: '${{ inputs.bot-name }} <${{steps.bot-email-set.outputs.bot-email}}>'
         commit-message: Update context.tf from origin source
         title: Update context.tf
         body: |-

--- a/context_update.sh
+++ b/context_update.sh
@@ -3,6 +3,7 @@
 echo "HOST_REPO: ${HOST_REPO}"
 if [[ "$HOST_REPO" == "cloudposse/github-action-terraform-auto-context" ]]; then
   mv ./test/context.tf .
+  echo "Moved context.f to top-level directory."
 fi
 
 git config --global --add safe.directory /github/workspace

--- a/context_update.sh
+++ b/context_update.sh
@@ -4,6 +4,7 @@ if [[ "$HOST_REPO" == "cloudposse/github-action-terraform-auto-context" ]]; then
   mv ./test/context.tf .
 fi
 
+git config --global --add safe.directory /github/workspace
 if [[ -f context.tf ]]; then
   echo "Discovered existing context.tf!"
   echo "Checking for pre-existing ${BRANCH_NAME} branch."

--- a/context_update.sh
+++ b/context_update.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-echo "HOST_REPO: ${HOST_REPO}"
 if [[ "$HOST_REPO" == "cloudposse/github-action-terraform-auto-context" ]]; then
   mv ./test/context.tf .
   echo "Moved context.tf to top-level directory."

--- a/context_update.sh
+++ b/context_update.sh
@@ -3,7 +3,7 @@
 echo "HOST_REPO: ${HOST_REPO}"
 if [[ "$HOST_REPO" == "cloudposse/github-action-terraform-auto-context" ]]; then
   mv ./test/context.tf .
-  echo "Moved context.f to top-level directory."
+  echo "Moved context.tf to top-level directory."
 fi
 
 git config --global --add safe.directory /github/workspace
@@ -14,7 +14,7 @@ if [[ -f context.tf ]]; then
     echo "Branch ${BRANCH_NAME} not found."
     echo "Fetching most recent version of context.tf to see if there is an update."
     curl -o context.tf -fsSL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf
-    if git diff --no-patch --exit-code context.tf; then
+    if [[ $(git diff --no-patch --exit-code context.tf) ]]; then
       echo "No changes detected! Exiting the job..."
     else
       # updating context.tf

--- a/context_update.sh
+++ b/context_update.sh
@@ -33,4 +33,5 @@ fi
 
 if [[ "$HOST_REPO" == "cloudposse/github-action-terraform-auto-context" ]]; then
   mv context.tf ./test/
+  echo "Moved context.tf back to ./test/ directory."
 fi

--- a/context_update.sh
+++ b/context_update.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+echo "HOST_REPO: ${HOST_REPO}"
 if [[ "$HOST_REPO" == "cloudposse/github-action-terraform-auto-context" ]]; then
   mv ./test/context.tf .
 fi

--- a/test/context.tf
+++ b/test/context.tf
@@ -1,3 +1,5 @@
+
+
 #
 # ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
 # All other instances of this file should be a copy of that one


### PR DESCRIPTION
## what

Changing the default value of the GHA input `bot-email` to null and then setting it to the GitHub default of whichever user was specified in the `bot-email` input during the GHA run.

Also, adopting reusable workflow topology.

## why

The functionality surrounding the `bot-email` field allows us to always have a logical email for bot-generated commits.

The reusable workflow topology is necessary for using custom GitHub runners.

## References

CPCO-580