### PR TITLE
Enabling version pinning

### DIFF
--- a/.github/workflows/auto-context-reusable.yml
+++ b/.github/workflows/auto-context-reusable.yml
@@ -24,7 +24,7 @@ jobs:
   auto-context:
     runs-on: ubuntu-latest
     steps:
-    - uses: cloudposse/github-action-terraform-auto-context@main
+    - uses: cloudposse/github-action-terraform-auto-context@0.2.0
       with:
         branch-name: ${{ inputs.branch-name }}
         bot-name: ${{ inputs.bot-name }}

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   auto-context:
+    # For development reasons, this action is pinned to the `main` branch.
+    # However, we recommend that you choose a specific release to pin to.
+    # Consult https://github.com/cloudposse/github-action-auto-context/releases for a list of available releases.
     uses: cloudposse/github-action-terraform-auto-context/.github/workflows/auto-context-reusable.yml@main
     with:
       # Name of branch to commit updated context.tf to

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ with:
 
 Here's how to get started...
 1. Copy this repository's `.github/workflows/auto-context.yml` file into the `.github/workflows` folder of the repository to which you'd like to add Terraform Auto-context functionality.
+2. (Optional) Update the `main` pin inside `auto-context.yml` to a fixed version. Consult https://github.com/cloudposse/github-action-auto-context/releases for a list of available versions.
 
 
 ## Examples

--- a/README.yaml
+++ b/README.yaml
@@ -96,6 +96,7 @@ examples: |-
 quickstart: |-
   Here's how to get started...
   1. Copy this repository's `.github/workflows/auto-context.yml` file into the `.github/workflows` folder of the repository to which you'd like to add Terraform Auto-context functionality.
+  2. (Optional) Update the `main` pin inside `auto-context.yml` to a fixed version. Consult https://github.com/cloudposse/github-action-auto-context/releases for a list of available versions.
 
 # Contributors to this project
 contributors:


### PR DESCRIPTION
## what
* Updating pin inside `auto-context-reusable.yml` to `0.2.0`.

## why
* This allows users to pin their actions to version `0.2.0` by editing their copies of `auto-context.yml` to call `auto-context-reusable.yml@0.2.1` (not `@0.2.0`, mind you).