### PR TITLE
Update github output syntax

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
         else
           bot_email=${{ inputs.bot-email }}
         fi
-        echo "::set-output name=bot-email::${bot_email}"
+        echo "bot-email=${bot_email}" >> $GITHUB_OUTPUT
 
     - name: "Checkout commit"
       uses: actions/checkout@v2


### PR DESCRIPTION
## what
Update github output syntax

## why
Following github docs

## references
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/